### PR TITLE
added note for non-azuread devices

### DIFF
--- a/wip/at-work-pro/wip-4-biz-install.md
+++ b/wip/at-work-pro/wip-4-biz-install.md
@@ -39,8 +39,7 @@ Administrators can install and manage Insider Preview builds centrally across de
 
 For instructions, see [Manage Windows Insider Preview builds](wip-4-biz-manage-builds.md).
 
-> [!NOTE]
-> In this scenario, when the device of the user is not already Azure AD joined, the user still needs to add an Azure AD or Microsoft account to the machine manually. Otherwise, Windows Insider Preview builds will not be received.
+<b>NOTE:</b> If the user's device is not already Azure AD joined, the user needs to add an Azure AD or Microsoft account to the machine manually. Otherwise, Windows Insider Preview builds will not be installed.
 
 ## Install on a virtual machine
 There isn't anything special you have to do to run Windows 10 Insider Preview builds on a virtual machine. Once you have a virtual machine set up, you install just as you would on an individual device. If you need help setting up a virtual machine, see [Introduction to Hyper-V on Windows 10](https://docs.microsoft.com/virtualization/hyper-v-on-windows/about/).

--- a/wip/at-work-pro/wip-4-biz-install.md
+++ b/wip/at-work-pro/wip-4-biz-install.md
@@ -39,6 +39,9 @@ Administrators can install and manage Insider Preview builds centrally across de
 
 For instructions, see [Manage Windows Insider Preview builds](wip-4-biz-manage-builds.md).
 
+> [!NOTE]
+> In this scenario, when the device of the user is not already Azure AD joined, the user still needs to add an Azure AD or Microsoft account to the machine manually. Otherwise, Windows Insider Preview builds will not be received.
+
 ## Install on a virtual machine
 There isn't anything special you have to do to run Windows 10 Insider Preview builds on a virtual machine. Once you have a virtual machine set up, you install just as you would on an individual device. If you need help setting up a virtual machine, see [Introduction to Hyper-V on Windows 10](https://docs.microsoft.com/virtualization/hyper-v-on-windows/about/).
 


### PR DESCRIPTION
An extra step is needed for non-azure ad domain joined machines when managing Windows Insider preview build trough GPO.
As long as there is nog Azure AD or Microsoft account is available, Insider builds will not be installed.