### PR TITLE
Updated the DISM command line to include quotes

### DIFF
--- a/wip/at-work/Whats-new-wip-at-work.md
+++ b/wip/at-work/Whats-new-wip-at-work.md
@@ -66,7 +66,7 @@ To install Server Core with FoD binaries
 ```Mount-DiskImage -ImagePath drive_letter:\folder_where_ISO_is_saved```
 8. Enter __exit__ to exit PowerShell.
 9. Enter the following command:
-```DISM /Online /Add-Capability /CapabilityName:ServerCore.Appcompatibility~~~~0.0.1.0 /Source:drive_letter_of_mounted_ISO: /LimitAccess ```
+```DISM /Online /Add-Capability /CapabilityName:"ServerCore.Appcompatibility~~~~0.0.1.0" /Source:drive_letter_of_mounted_ISO: /LimitAccess ```
 10. After the progress bar completes, restart the operating system at the prompt.
 
 __Note__ This FoD is required for installation of Internet Explorer 11, but installing Internet Explorer 11 is optional


### PR DESCRIPTION
On my machines in order to get this to work i needed to include the "" around ServerCore.Appcompatibility~~~~0.0.1.0 so that it becomes "ServerCore.Appcompatibility~~~~0.0.1.0" after that i can copy and paste it into the command line and install the FOD features without the  Error 87 A Windows capability name was not recognized