### PR TITLE
Updated exploit guard section to take out the \

### DIFF
--- a/wip/at-work/Whats-new-wip-at-work.md
+++ b/wip/at-work/Whats-new-wip-at-work.md
@@ -205,41 +205,23 @@ Set-MpPreference -EnableControlledFolderAccess Enabled
 
 Set-MpPreference -EnableNetworkProtection Enabled
 
-Add-MpPreference -AttackSurfaceReductionRules\_Ids
-75668C1F-73B5-4CF0-BB93-3ECF5CB7CC84
--AttackSurfaceReductionRules\_Actions Enabled
+Add-MpPreference -AttackSurfaceReductionRules_Ids 75668C1F-73B5-4CF0-BB93-3ECF5CB7CC84 -AttackSurfaceReductionRules_Actions Enabled
 
-Add-MpPreference -AttackSurfaceReductionRules\_Ids
-3B576869-A4EC-4529-8536-B80A7769E899
--AttackSurfaceReductionRules\_Actions Enabled
+Add-MpPreference -AttackSurfaceReductionRules_Ids 3B576869-A4EC-4529-8536-B80A7769E899 -AttackSurfaceReductionRules_Actions Enabled
 
-Add-MpPreference -AttackSurfaceReductionRules\_Ids
-D4F940AB-401B-4EfC-AADC-AD5F3C50688A
--AttackSurfaceReductionRules\_Actions Enabled
+Add-MpPreference -AttackSurfaceReductionRules_Ids D4F940AB-401B-4EfC-AADC-AD5F3C50688A -AttackSurfaceReductionRules_Actions Enabled
 
-Add-MpPreference -AttackSurfaceReductionRules\_Ids
-D3E037E1-3EB8-44C8-A917-57927947596D
--AttackSurfaceReductionRules\_Actions Enabled
+Add-MpPreference -AttackSurfaceReductionRules_Ids D3E037E1-3EB8-44C8-A917-57927947596D -AttackSurfaceReductionRules_Actions Enabled
 
-Add-MpPreference -AttackSurfaceReductionRules\_Ids
-5BEB7EFE-FD9A-4556-801D-275E5FFC04CC
--AttackSurfaceReductionRules\_Actions Enabled
+Add-MpPreference -AttackSurfaceReductionRules_Ids 5BEB7EFE-FD9A-4556-801D-275E5FFC04CC -AttackSurfaceReductionRules_Actions Enabled
 
-Add-MpPreference -AttackSurfaceReductionRules\_Ids
-BE9BA2D9-53EA-4CDC-84E5-9B1EEEE46550
--AttackSurfaceReductionRules\_Actions Enabled
+Add-MpPreference -AttackSurfaceReductionRules_Ids BE9BA2D9-53EA-4CDC-84E5-9B1EEEE46550 -AttackSurfaceReductionRules_Actions Enabled
 
-Add-MpPreference -AttackSurfaceReductionRules\_Ids
-92E97FA1-2EDF-4476-BDD6-9DD0B4DDDC7B
--AttackSurfaceReductionRules\_Actions Enabled
+Add-MpPreference -AttackSurfaceReductionRules_Ids 92E97FA1-2EDF-4476-BDD6-9DD0B4DDDC7B -AttackSurfaceReductionRules_Actions Enabled
 
-Add-MpPreference -AttackSurfaceReductionRules\_Ids
-D1E49AAC-8F56-4280-B9BA-993A6D77406C
--AttackSurfaceReductionRules\_Actions Disabled
+Add-MpPreference -AttackSurfaceReductionRules_Ids D1E49AAC-8F56-4280-B9BA-993A6D77406C -AttackSurfaceReductionRules_Actions Disabled
 
-Add-MpPreference -AttackSurfaceReductionRules\_Ids
-01443614-cd74-433a-b99e-2ecdc07bfc25
--AttackSurfaceReductionRules\_Actions Enabled
+Add-MpPreference -AttackSurfaceReductionRules_Ids 01443614-cd74-433a-b99e-2ecdc07bfc25 -AttackSurfaceReductionRules_Actions Enabled
 
 $url = 'https://demo.wd.microsoft.com/Content/ProcessMitigation.xml'
 


### PR DESCRIPTION
the \ cause issues and the end users are not able to just copy and past these commands into powershell, taking out the \ allows the commands to be run without error.