### PR TITLE
Update Whats-new-wip-at-home.md

### DIFF
--- a/wip/at-home/Whats-new-wip-at-home.md
+++ b/wip/at-home/Whats-new-wip-at-home.md
@@ -52,7 +52,7 @@ Our new settings page for enabling this experience is under __Settings > System 
 
 ![clipboard settings](images/clipboardsettings.png "clipboard settings")
 
-__Note:__ Roaming text on the clipboard is only supported for clipboard content less than 100kb. Currently, the clipboard history supports plain text, HTML and images less than 1MB. 
+__Note:__ Roaming text on the clipboard is only supported for clipboard content less than 100kb. Currently, the clipboard history supports plain text, HTML and images less than 4MB. 
 
 ## Cortana Show Me voice queries
  You can now launch the Cortana Show Me app through voice queries. Simply say to Cortana, “Show me how to change my background,” and you’ll get help content, with a new “Let’s go” button below, which launches the guided help experience. 


### PR DESCRIPTION
Under the "Note:" for the new Clipboard Experience in RS5 in these docs, it indicates supported images up to 1MB in size however, according to the Windows 10 RS5 Build 17741 Release Notes at https://blogs.windows.com/windowsexperience/2018/08/17/build17741/ that limit has been raised to 4MB "to accommodate the potential size of full screen screenshots taken on a high-DPI devices."
Windows-Insider "What's New" docs should be updated to reflect this change.