### PR TITLE
19H1 build is now being offered in Slow Ring

### DIFF
--- a/wip/flight-hub/index.md
+++ b/wip/flight-hub/index.md
@@ -42,7 +42,7 @@ The items in **bold** are the latest releases for the individual versions of the
 
 ## Next feature update for Windows 10 (19H1)
 
-You can get builds of 19H1 today if your device is in the Fast ring.
+You can get builds of 19H1 today if your device is in the Slow ring.
 
 The items in **bold** are the latest releases for the individual versions of the item. 
 


### PR DESCRIPTION
Made a correction where 19H1 build is now available in slow ring. Where as 20H1 is now available in Fast Ring as per Microsoft blog post https://blogs.windows.com/windowsexperience/2019/05/01/announcing-windows-10-insider-preview-build-18890/

Problem:https://github.com/MicrosoftDocs/windows-insider/issues/164