### PR TITLE
update iso index for build 18917

### DIFF
--- a/wip/flight-hub/index.md
+++ b/wip/flight-hub/index.md
@@ -17,6 +17,7 @@ Welcome to Flight Hub! Use this dashboard to quickly identify the latest Windows
 
 ## Skip Ahead and Fast builds for Windows 10 (20H1)
 
+
 You can get builds of 20H1 today if you've opted in to **Fast builds**.
 
 The items in **bold** are the latest releases for the individual versions of the item. 


### PR DESCRIPTION
can you please add the link below, under the iso cell for build 18917. When I click this link: and hit edit, the github version looks different than what is live. I am not sure why so I could not make any edits to the code above. Can you please add think link: https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewadvanced?lc=1033&wa=wsignin1.0



with the hyperlink text: 6/18/2019