### PR TITLE
update link to current build

### DIFF
--- a/wip/at-home/index.md
+++ b/wip/at-home/index.md
@@ -82,3 +82,4 @@ The [Windows Insider Program](https://insider.windows.com/en-us/) lets you insta
         </a>
     </li> 
 </ul>
+


### PR DESCRIPTION
I am not seeing the link on this page when I try to edit so I will type out the edit I would like to see and ask for help.

Thanks, sorry for the trouble, see picture for example. 

Update the "What's new" link to redirect to the 20H1 page not 19H1 anymore as that is not the current one.

https://docs.microsoft.com/en-us/windows-insider/at-home/Whats-new-wip-at-home-20h1