### PR TITLE
Update Flight Hub to include latest 20H1 builds

### DIFF
--- a/wip/flight-hub/index.md
+++ b/wip/flight-hub/index.md
@@ -23,7 +23,8 @@ The items in **bold** are the latest releases for the individual versions of the
 
 | Build | Fast | Slow | Server | IoT | ISO | SDK |
 |-------|------|------|--------|-----|-----|-----|
-|19002|[**10/17/2019**](https://blogs.windows.com/windowsexperience/2019/10/17/announcing-windows-10-insider-preview-build-19002/)|||||[**10/22/2019**](https://blogs.windows.com/windowsdeveloper/2019/10/22/windows-10-sdk-preview-build-19002-available-now/#CTtMjtzQR1dU2reO.97)|
+|19008|[**10/22/2019**](https://blogs.windows.com/windowsexperience/2019/10/22/announcing-windows-10-insider-preview-build-19008/)||||||
+|19002|[10/17/2019](https://blogs.windows.com/windowsexperience/2019/10/17/announcing-windows-10-insider-preview-build-19002/)|||||[**10/22/2019**](https://blogs.windows.com/windowsdeveloper/2019/10/22/windows-10-sdk-preview-build-19002-available-now/)|
 |18999|[10/8/2019](https://blogs.windows.com/windowsexperience/2019/10/08/announcing-windows-10-insider-preview-build-18999/)|||||[10/15/2019](https://blogs.windows.com/windowsdeveloper/2019/10/15/windows-10-sdk-preview-build-18999-available-now/)|
 |18995|[10/3/2019](https://blogs.windows.com/windowsexperience/2019/10/03/announcing-windows-10-insider-preview-build-18995/)||[**10/8/2019**](https://blogs.windows.com/windowsexperience/2019/10/08/announcing-windows-server-vnext-insider-preview-build-18995/)|||[10/10/2019](https://blogs.windows.com/windowsdeveloper/2019/10/10/windows-10-sdk-preview-build-18995-available-now/)|
 |18990|[9/24/2019](https://blogs.windows.com/windowsexperience/2019/09/24/announcing-windows-10-insider-preview-build-18990/)||||[**10/1/2019**](https://www.microsoft.com/software-download/windowsinsiderpreviewadvanced)|[10/1/2019](https://blogs.windows.com/windowsdeveloper/2019/10/01/windows-10-sdk-preview-build-18990-available-now/)|


### PR DESCRIPTION
* Added build **19008** which flighted on **10/22/2019** for the **Insider Fast** ring