### PR TITLE
Update Flight Hub to include latest 19H2 builds

### DIFF
--- a/wip/flight-hub/index.md
+++ b/wip/flight-hub/index.md
@@ -64,15 +64,16 @@ The items in **bold** are the latest releases for the individual versions of the
 
 For details regarding the 19H2 feature update for Windows 10, see [Evolving Windows 10 servicing: the next steps](https://blogs.windows.com/windowsexperience/2019/07/01/evolving-windows-10-servicing-and-quality-the-next-steps/).
 
-On 10/10/2019, we [announced](https://blogs.windows.com/windowsexperience/2019/10/10/getting-the-november-2019-update-ready-for-release/#gl8uKqe3aYdymFzc.97) 19H2 will be the November 2019 Update (Version 1909) and that Build 18363.418 is the final build. We will continue to improve the overall experience of 19H2 on customers’ PCs as part of our normal servicing cadence. This means we will continue to iterate and release new Cumulative Updates for 19H2. You will see these new Cumulative Updates noted below and we will continue to note them here until General Availability. 
+On 10/10/2019, we [announced](https://blogs.windows.com/windowsexperience/2019/10/10/getting-the-november-2019-update-ready-for-release/) 19H2 will be the November 2019 Update (Version 1909) and that Build 18363.418 is the final build. We will continue to improve the overall experience of 19H2 on customers’ PCs as part of our normal servicing cadence. This means we will continue to iterate and release new Cumulative Updates for 19H2. You will see these new Cumulative Updates noted below and we will continue to note them here until General Availability.
 
 **19H2 in the Release Preview ring:**
 
 | Build | Release Preview | ISO |
 |-------|-----------------|-----|
-|18363.448|[**10/18/2019**](https://blogs.windows.com/windowsexperience/2019/10/10/getting-the-november-2019-update-ready-for-release/#gl8uKqe3aYdymFzc.97)||
-|18363.446|[10/17/2019](https://blogs.windows.com/windowsexperience/2019/10/10/getting-the-november-2019-update-ready-for-release/#gl8uKqe3aYdymFzc.97)||
-|18363.418|[10/8/2019](https://blogs.windows.com/windowsexperience/2019/10/10/getting-the-november-2019-update-ready-for-release/#gl8uKqe3aYdymFzc.97)||
+|18363.449|[**10/24/2019**](https://blogs.windows.com/windowsexperience/2019/10/10/getting-the-november-2019-update-ready-for-release/)||
+|18363.448|[10/18/2019](https://blogs.windows.com/windowsexperience/2019/10/10/getting-the-november-2019-update-ready-for-release/)||
+|18363.446|[10/17/2019](https://blogs.windows.com/windowsexperience/2019/10/10/getting-the-november-2019-update-ready-for-release/)||
+|18363.418|[10/8/2019](https://blogs.windows.com/windowsexperience/2019/10/10/getting-the-november-2019-update-ready-for-release/)||
 |18363.388*|[10/3/2019](https://blogs.windows.com/windowsexperience/2019/08/26/testing-the-throttled-delivery-approach-for-19h2/)||
 |18363.387*|[9/27/2019](https://blogs.windows.com/windowsexperience/2019/08/26/testing-the-throttled-delivery-approach-for-19h2/)||
 |18363.385*|[9/23/2019](https://blogs.windows.com/windowsexperience/2019/08/26/testing-the-throttled-delivery-approach-for-19h2/)||
@@ -84,7 +85,7 @@ On 10/10/2019, we [announced](https://blogs.windows.com/windowsexperience/2019/1
 
 **19H2 in the Slow ring:**
 
-As of 10/16/2019 - the Slow ring will no longer be updated with new 19H2 builds. 
+As of 10/16/2019 - the Slow ring will no longer be updated with new 19H2 builds.
 
 | Build | Slow |
 |-------|------|
@@ -144,7 +145,7 @@ The [Windows 10 May 2019 Update](https://blogs.windows.com/windowsexperience/201
 
 ## Windows 10 October 2018 Update (RS5)
 
-Windows 10, version 1809, and Windows Server 2019 were released to the world on November 13, 2018. 
+Windows 10, version 1809, and Windows Server 2019 were released to the world on November 13, 2018.
 
 | Build | Fast | Slow | Server | IoT | ISO | SDK |
 |-------|------|------|--------|-----|-----|-----|


### PR DESCRIPTION
* Added build **18363.449** which flighted on **10/24/2019** for the **Release Preview** ring