### PR TITLE
Updated Flight Hub to include Insider Dev Build 20190

### DIFF
--- a/wip/flight-hub/index.md
+++ b/wip/flight-hub/index.md
@@ -22,8 +22,9 @@ Welcome to Flight Hub! Use this dashboard to quickly identify the latest Windows
 Moving forward, the Dev Channel will receive builds directly from the active development branch, and new features will show up in these builds first. While features in the active development branch may be slated for a future Windows 10 release, they are no longer matched to a specific Windows 10 release. This means that builds from the active development branch simply reflect the latest work in progress code from our engineers.
 
 | Build | Dev | SDK | ISO |
-|-------|------|------|
-|20185|[**8/5/2020**](https://blogs.windows.com/windowsexperience/2020/08/05/announcing-windows-10-insider-preview-build-20185/)|[**8/5/2020**](https://software-download.microsoft.com/download/sg/Windows_InsiderPreview_SDK_en-us_20185_1.iso)||
+|-------|------|------|-------|
+| 20190 | [**8/12/2020**](https://blogs.windows.com/windowsexperience/2020/08/12/announcing-windows-10-insider-preview-build-20190/) |  |  |
+|20185|[8/5/2020](https://blogs.windows.com/windowsexperience/2020/08/05/announcing-windows-10-insider-preview-build-20185/)|[8/5/2020](https://software-download.microsoft.com/download/sg/Windows_InsiderPreview_SDK_en-us_20185_1.iso)||
 |20180|[7/29/2020](https://blogs.windows.com/windowsexperience/2020/07/29/announcing-windows-10-insider-preview-build-20180/)|[7/29/2020](https://software-download.microsoft.com/download/sg/Windows_InsiderPreview_SDK_en-us_20180_1.iso)||
 |20175|[7/22/2020](https://blogs.windows.com/windowsexperience/2020/07/22/announcing-windows-10-insider-preview-build-20175/)|[7/22/2020](https://software-download.microsoft.com/download/sg/Windows_InsiderPreview_SDK_en-us_20175_1.iso)||
 |20170|[7/15/2020](https://blogs.windows.com/windowsexperience/2020/07/15/announcing-windows-10-insider-preview-build-20170/)|[7/15/2020](https://software-download.microsoft.com/download/sg/Windows_InsiderPreview_SDK_en-us_20170_1.iso)||


### PR DESCRIPTION
I've updated the Flight Hub document to include Dev Build 20190, as it is not yet listed.